### PR TITLE
Included 5.8 inch screen size for iPhone X

### DIFF
--- a/Sources/Screen.swift
+++ b/Sources/Screen.swift
@@ -47,6 +47,7 @@ extension Screen {
         case (568, _): return 4.0
         case (667, 3.0), (736, _): return 5.5
         case (667, 1.0), (667, 2.0): return 4.7
+        case (812, 3.0): return 5.8
         case (1024, _): return ipadSize1024()
         case (1112, _): return 10.5
         case (1366, _): return 12.9


### PR DESCRIPTION
Otherwise, it will return as nil.